### PR TITLE
H2 설정 및 공통 BaseEntity 도입, 테스트 API 추가

### DIFF
--- a/src/main/java/com/feelory/feelory_backend/FeeloryBackendApplication.java
+++ b/src/main/java/com/feelory/feelory_backend/FeeloryBackendApplication.java
@@ -2,7 +2,9 @@ package com.feelory.feelory_backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class FeeloryBackendApplication {
 

--- a/src/main/java/com/feelory/feelory_backend/global/BaseEntity.java
+++ b/src/main/java/com/feelory/feelory_backend/global/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.feelory.feelory_backend.global;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/feelory/feelory_backend/sample/contoller/SampleController.java
+++ b/src/main/java/com/feelory/feelory_backend/sample/contoller/SampleController.java
@@ -1,23 +1,22 @@
 package com.feelory.feelory_backend.sample.contoller;
 
 import com.feelory.feelory_backend.sample.service.SampleService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/sample")
 public class SampleController {
 
+    private final SampleService sampleService;
+
     @Value("${sample.hello}")
     private String STR_HELLO;
-
-    SampleService sampleService;
-
-    public SampleController(SampleService sampleService) {
-        this.sampleService = sampleService;
-    }
 
     @GetMapping("hello")
     public String sendHelloWorld() {
@@ -29,5 +28,12 @@ public class SampleController {
     public String sendSampleTextFromDB() {
 
         return sampleService.getSampleTextFromDB();
+    }
+
+    @PostMapping("db-data")
+    public String insertSampleText() {
+        sampleService.insertSampleText();
+
+        return "DB 데이터 저장 완료";
     }
 }

--- a/src/main/java/com/feelory/feelory_backend/sample/entity/SampleTable.java
+++ b/src/main/java/com/feelory/feelory_backend/sample/entity/SampleTable.java
@@ -2,6 +2,7 @@ package com.feelory.feelory_backend.sample.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,4 +17,20 @@ public class SampleTable {
 
     @Column(name = "txt")
     private String txt;
+
+    @Column(name = "name", nullable = false, length = 20)
+    private String name;
+
+    @Builder
+    private SampleTable(String txt, String name){
+        this.txt = txt;
+        this.name = name;
+    }
+
+    public static SampleTable of(String txt, String name){
+        return SampleTable.builder()
+                .txt(txt)
+                .name(name)
+                .build();
+    }
 }

--- a/src/main/java/com/feelory/feelory_backend/sample/entity/SampleTable.java
+++ b/src/main/java/com/feelory/feelory_backend/sample/entity/SampleTable.java
@@ -1,5 +1,6 @@
 package com.feelory.feelory_backend.sample.entity;
 
+import com.feelory.feelory_backend.global.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class SampleTable {
+public class SampleTable extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/feelory/feelory_backend/sample/service/SampleService.java
+++ b/src/main/java/com/feelory/feelory_backend/sample/service/SampleService.java
@@ -2,22 +2,25 @@ package com.feelory.feelory_backend.sample.service;
 
 import com.feelory.feelory_backend.sample.entity.SampleTable;
 import com.feelory.feelory_backend.sample.repository.SampleTableRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class SampleService {
 
-    private SampleTableRepository sampleTableRepository;
-
-    public SampleService(SampleTableRepository sampleTableRepository) {
-        this.sampleTableRepository = sampleTableRepository;
-    }
+    private final SampleTableRepository sampleTableRepository;
 
     public String getSampleTextFromDB() {
         Long id = 1L;
         SampleTable sampleData = sampleTableRepository.findById(id)
-                .orElse(new SampleTable());
+                .orElse(SampleTable.of("저장된 내용이 없습니다.","시스템"));
 
         return sampleData.getTxt();
+    }
+
+    public void insertSampleText(){
+        SampleTable A = SampleTable.of("H2 DB 입출력 테스트","김강산");
+        sampleTableRepository.save(A);
     }
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,16 @@
+# JPA
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.open-in-view=false
+
+# DB(H2)
+spring.datasource.url=jdbc:h2:file:./data/feelory-db
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+# H2
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,16 @@
+# DB(MySQL)
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=ENC(9/uK+82PKZRfqGUzXD2vePTcfHbT8a/dFgoJcgpMtv4+b9TuMiHWDWeLvrDG8AtG19CH2QnI8Jpvt6dwPtu8KYO0HW1vAGi4k9H9d7UOsuRpBPuuwb9WXQWZ3ydal8tKl7S6Kfz6G277vhfynKfxV1zrOLQgKPkF6IUbN3C7vxg=)
+spring.datasource.username=ENC(4u0bDbDQT6CoVl9ZT/SDl2uwAVuil+J7JUzVbUK7l0a//8YycZvAvgwB/sk2lrkg)
+spring.datasource.password=ENC(9Od8+MLyOgjlWzGhR7qOtElMuH8th4DO42sNRu1RM1qRNVnztskNc8inNyLv5A1E)
+
+# JPA
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.open-in-view=false
+
+# Static File Server
+static-file-server.upload=ENC(iGQbykuGt9iMTwz6/NEZAW4dhqZVMDJ3KlJnagDJaWiU6AMrdJCyNFZnW4FPG25bkTJeihdbAae7YKomAC4X3NKG2/IN7sGiIedmGU9ochv1uavZRfSEILhVpuS9chr1)
+static-file-server.download=ENC(YU2kief4hWb66TEBWIClxsICKczXbtKHCVEwLBJpyTwEBYkYgA4CaFVebqIemHt0odToVzPEd+IR3S9zbshaCAGMP59XuPfSNZGi4CBMH7g=)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,8 @@
 spring.application.name=feelory-backend
 
+# Set properties to use
+spring.profiles.active=dev  
+
 # JASYPT Encryptor
 jasypt.encryptor.algorithm=PBEWITHHMACSHA512ANDAES_256
 jasypt.encryptor.iv-generator-classname=org.jasypt.iv.RandomIvGenerator
@@ -8,20 +11,3 @@ jasypt.encryptor.salt-generator-classname=org.jasypt.salt.RandomSaltGenerator
 # Sample Properties
 sample.hello=ENC(aPolPv/yQqpRP/ivfbDkuwZ199WqJbeTTyxic7eLnCRJPkUvKRmgLGlVqER1WIHa)
 
-# Static File Server
-static-file-server.upload=ENC(iGQbykuGt9iMTwz6/NEZAW4dhqZVMDJ3KlJnagDJaWiU6AMrdJCyNFZnW4FPG25bkTJeihdbAae7YKomAC4X3NKG2/IN7sGiIedmGU9ochv1uavZRfSEILhVpuS9chr1)
-static-file-server.download=ENC(YU2kief4hWb66TEBWIClxsICKczXbtKHCVEwLBJpyTwEBYkYgA4CaFVebqIemHt0odToVzPEd+IR3S9zbshaCAGMP59XuPfSNZGi4CBMH7g=)
-
-
-# DB
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=ENC(9/uK+82PKZRfqGUzXD2vePTcfHbT8a/dFgoJcgpMtv4+b9TuMiHWDWeLvrDG8AtG19CH2QnI8Jpvt6dwPtu8KYO0HW1vAGi4k9H9d7UOsuRpBPuuwb9WXQWZ3ydal8tKl7S6Kfz6G277vhfynKfxV1zrOLQgKPkF6IUbN3C7vxg=)
-spring.datasource.username=ENC(4u0bDbDQT6CoVl9ZT/SDl2uwAVuil+J7JUzVbUK7l0a//8YycZvAvgwB/sk2lrkg)
-spring.datasource.password=ENC(9Od8+MLyOgjlWzGhR7qOtElMuH8th4DO42sNRu1RM1qRNVnztskNc8inNyLv5A1E)
-
-# JPA
-spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
-spring.jpa.hibernate.ddl-auto=none
-spring.jpa.properties.hibernate.show_sql=true
-spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.open-in-view=false


### PR DESCRIPTION
### ✨ 작업 개요

* 로컬 개발 환경과 배포 환경에 각각 사용될 properties 분리
* 빌더와 정적 팩토리 메서드 사용 방식 제안
* 로컬 개발 환경에서 사용할 H2 설정 및 테스트용 API 추가
* 공통 엔터티 속성(`createdAt`, `updatedAt`) 적용을 위한 `BaseEntity` 도입

---

### 🔧 변경사항

* **application.properties**
  * `spring.profiles.active=dev`로 기본적으로 로컬 개발 환경에서 `application-dev.properties` 사용하도록 설정했습니다.
  * 배포 시에는 해당 값을 `prod`로 변경이 필요합니다.
  * 두 환경에서 공통으로 사용할 설정들은 이쪽에 두었습니다.

* **application-dev.properties**
  * H2 DB 및 콘솔 설정을 추가했습니다.
  * JPA DDL 정책을 `create`로 설정하여, 서버 실행 시마다 DB가 재생성 됩니다.

* **application-prod.properties**
  * 배포용 설정을 이쪽으로 분리했습니다.

* **global/BaseEntity.java**
  * 모든 엔터티에서 공통으로 사용할 `createdAt`, `updatedAt` 필드를 갖는 추상 클래스를 추가했습니다.
  * `isActive` 는 엔터티마다 추가해야 합니다.

* **SampleTable.java**
  * 테스트용 컬럼을 추가했습니다.
  * `Builder` 및 `of()` 정적 팩토리 메서드를 추가했습니다. 엔터티를 외부에서 `of()` 로 일관되게 생성하는게 편해서 사용하고 있는데, 의견 부탁드립니다.
  * `BaseEntity`를 상속하여 생성일/수정일을 자동으로 관리할 수 있게 했습니다.

* **SampleService.java / SampleController.java**

  * POST API `/api/v1/sample/db-data` 추가하여 H2 DB에 데이터 저장 테스트가 가능합니다.
  * 의존성 주입 방식을 Lombok을 사용하는 방식으로 바꿨는데, 의견 부탁드립니다.

---

### 📝 테스트 방법

1. http://localhost:8080/h2-console/ 로 접속
2. JDBC URL : `jdbc:h2:file:./data/feelory-db`
3. POST 요청: `POST /api/v1/sample/db-data`
4. GET 요청: `GET /api/v1/sample/db`

---

### ⚡ 기타

---
