### PR TITLE
전역 예외 처리 구현, 파일 기반 로깅 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+/data/

--- a/src/main/java/com/feelory/feelory_backend/global/config/JpaConfig.java
+++ b/src/main/java/com/feelory/feelory_backend/global/config/JpaConfig.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
-@EnableJpaAuditing
 public class JpaConfig {
     @PersistenceContext
     private EntityManager em;

--- a/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/BaseException.java
+++ b/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/BaseException.java
@@ -1,0 +1,13 @@
+package com.feelory.feelory_backend.global.exception.exceptions;
+
+import lombok.Getter;
+
+@Getter
+public class BaseException extends RuntimeException {
+  private final ErrorCode errorCode;
+
+  protected BaseException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/ErrorCode.java
+++ b/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/ErrorCode.java
@@ -1,0 +1,36 @@
+package com.feelory.feelory_backend.global.exception.exceptions;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    // E0XX : AUTH(인증/토큰)
+
+    // E1XX : USERS(사용자)
+    USERS_NOT_FOUND(HttpStatus.NOT_FOUND, "E100", "해당 유저를 찾을 수 없습니다."),
+
+    // E2XX : WORDS(단어)
+    WORDS_NOT_FOUND(HttpStatus.NOT_FOUND, "E200", "단어를 찾을 수 없습니다."),
+
+    // E3XX : WRITINGS(글)
+
+    // E4XX : LIKES, BOOKMARKS (좋아요, 북마크)
+
+    // E5XX : FEEDBACKS(피드백)
+
+    // E9XX : 기타
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E999", "서버 내부 오류가 발생했습니다.");
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/ErrorResponse.java
+++ b/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/ErrorResponse.java
@@ -1,0 +1,17 @@
+package com.feelory.feelory_backend.global.exception.exceptions;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private final HttpStatus status;
+    private final String message;
+
+    public ErrorResponse(ErrorCode errorCode) {
+        this.status = errorCode.getStatus();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/ExceptionFileLogger.java
+++ b/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/ExceptionFileLogger.java
@@ -1,0 +1,49 @@
+package com.feelory.feelory_backend.global.exception.exceptions;
+
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Component
+public class ExceptionFileLogger {
+
+    private static final String ERROR_LOG_DIR = "data/logs";
+
+    public void writeToFile(Exception exception) {
+        String timestamp = LocalDateTime.now()
+                .format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmssSSS"));
+        String fileName = "error_" + timestamp + ".txt";
+
+        try {
+            File dir = new File(ERROR_LOG_DIR);
+            if (!dir.exists()) dir.mkdirs();
+
+            File logFile = new File(dir, fileName);
+
+            try (FileWriter writer = new FileWriter(logFile)) {
+                writer.write("📌 예외 요약\n");
+                writer.write("----------------------------------\n");
+                writer.write("🕒 발생 시각: " + timestamp + "\n");
+                writer.write("🚨 예외 타입: " + exception.getClass().getName() + "\n");
+                writer.write("🧩 메시지: " + exception.getMessage() + "\n");
+
+                StackTraceElement origin = exception.getStackTrace()[0];
+                writer.write("📍 발생 위치: " + origin + "\n");
+
+                writer.write("\n🔽 전체 스택트레이스\n");
+                writer.write("----------------------------------\n");
+
+                for (StackTraceElement element : exception.getStackTrace()) {
+                    writer.write(element.toString() + "\n");
+                }
+            }
+
+        } catch (IOException e) {
+            System.err.println("에러 로그 파일 저장 실패: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/handler/GlobalExceptionHandler.java
@@ -1,0 +1,47 @@
+package com.feelory.feelory_backend.global.exception.exceptions.handler;
+
+import com.feelory.feelory_backend.global.exception.exceptions.BaseException;
+import com.feelory.feelory_backend.global.exception.exceptions.ErrorCode;
+import com.feelory.feelory_backend.global.exception.exceptions.ExceptionFileLogger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import lombok.extern.slf4j.Slf4j;
+
+
+@RequiredArgsConstructor
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private final ExceptionFileLogger exceptionFileLogger;
+
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<String> handleBaseException(BaseException exception) {
+
+        ErrorCode errorCode = exception.getErrorCode();
+//        ErrorResponse errorResponse = new ErrorResponse(code);
+//        ApiResponse<ErrorResponse> apiResponse = ApiResponse.error(errorResponse);
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+//                .body(apiResponse);
+                .body(errorCode.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException(Exception exception) {
+
+        exceptionFileLogger.writeToFile(exception);
+
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+//        ErrorResponse errorResponse = new ErrorResponse(code);
+//        ApiResponse<ErrorResponse> apiResponse = ApiResponse.error(errorResponse);
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+//                .body(apiResponse);
+                .body(errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/users/UsersNotFoundException.java
+++ b/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/users/UsersNotFoundException.java
@@ -1,0 +1,11 @@
+package com.feelory.feelory_backend.global.exception.exceptions.users;
+
+import com.feelory.feelory_backend.global.exception.exceptions.ErrorCode;
+import com.feelory.feelory_backend.global.exception.exceptions.BaseException;
+
+public class UsersNotFoundException extends BaseException {
+
+    public UsersNotFoundException() {
+        super(ErrorCode.USERS_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/words/WordsNotFoundException.java
+++ b/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/words/WordsNotFoundException.java
@@ -1,0 +1,11 @@
+package com.feelory.feelory_backend.global.exception.exceptions.words;
+
+import com.feelory.feelory_backend.global.exception.exceptions.ErrorCode;
+import com.feelory.feelory_backend.global.exception.exceptions.BaseException;
+
+public class WordsNotFoundException extends BaseException {
+
+    public WordsNotFoundException() {
+        super(ErrorCode.WORDS_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/feelory/feelory_backend/sample/contoller/SampleController.java
+++ b/src/main/java/com/feelory/feelory_backend/sample/contoller/SampleController.java
@@ -36,4 +36,16 @@ public class SampleController {
 
         return "DB 데이터 저장 완료";
     }
+
+    @GetMapping("throw-base-exception")
+    public String throwBaseException() {
+        sampleService.throwBaseException();
+        return "이 메시지는 절대 도달하지 않습니다.";
+    }
+
+    @GetMapping("throw-unknown-exception")
+    public String throwUnknownException() {
+        sampleService.throwUnknownException();
+        return "이 메시지도 도달하지 않습니다.";
+    }
 }

--- a/src/main/java/com/feelory/feelory_backend/sample/service/SampleService.java
+++ b/src/main/java/com/feelory/feelory_backend/sample/service/SampleService.java
@@ -1,5 +1,6 @@
 package com.feelory.feelory_backend.sample.service;
 
+import com.feelory.feelory_backend.global.exception.exceptions.users.UsersNotFoundException;
 import com.feelory.feelory_backend.sample.entity.SampleTable;
 import com.feelory.feelory_backend.sample.repository.SampleTableRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,5 +23,14 @@ public class SampleService {
     public void insertSampleText(){
         SampleTable A = SampleTable.of("H2 DB 입출력 테스트","김강산");
         sampleTableRepository.save(A);
+    }
+
+    public void throwBaseException() {
+        throw new UsersNotFoundException();
+    }
+
+    public void throwUnknownException() {
+        String text = null;
+        text.length(); // NPE 발생
     }
 }


### PR DESCRIPTION
### ✨ 작업 개요
- 전역 예외 처리 시스템 구현
  - 에러 응답 구조 설정
  - 예외 관리 Enum 추가
  - 테스트용 예외 2종 추가
  - 예외 파일 로깅 추가
- 이 외 약간의 버그 수정 및 설정 변경

---

### 🔧 변경사항

* **`JpaConfig.java`**
  * 중복된 `@EnableJpaAuditing` 어노테이션 제거
  * `FeeloryBackendApplication` 와 겹쳐서 컴파일이 안되더군요
  * `@SpringBootApplication` 에만 두는게 일반적이라길래, 제가 임의로 제거했습니다.
* **`.gitignore`**
  * H2 DB , 에러 로깅 파일등을 디렉토리 Git 추적에서 제외하도록 수정했습니다.
* **전역 예외 처리 관련 클래스 추가**
  * `BaseException.java`
    * 모든 커스텀 예외가 상속받아야하는 상위 클래스 입니다.
  * `ErrorCode.java`
    * 예외 코드 및 메시지 정의 (`USERS_NOT_FOUND`, `WORDS_NOT_FOUND` 등 포함)
    * 각 도메인에 맞게 임시로 분류해 놓았습니다.(필요시 수정 가능)
  * `ErrorResponse.java`
    * 예외 응답 객체
  * `GlobalExceptionHandler.java`
    * 전역 예외 처리 클래스 (`@RestControllerAdvice`)
    * 현재 ApiResponse에 담아서 응답하는 부분을 주석 처리하고, 임시로 `String` 으로 반환하게 해두었습니다. 
    * 기본적으로 `BaseException`을 상속하는 커스텀 예외를 처리합니다.
    * 예상치 못한 일반 예외는 파일로 로깅하여 추적할 수 있게 해두었습니다.
  * `ExceptionFileLogger.java`
    * 처리되지 않은 예외를 `data/logs/` 디렉토리에 개별 `.txt` 파일로 저장합니다.
* **`UsersNotFoundException.java` / `WordsNotFoundException.java`**
  * 커스텀 예외 클래스 2개 추가
  * 각각 `ErrorCode`를 기반으로 생성
* **`SampleController.java` / `SampleService.java`**
  * 예외 테스트용 API 2개 추가:
    * `GET /throw-base-exception`: 커스텀 예외 발생 (`UsersNotFoundException`)
    * `GET /throw-unknown-exception`: 예상치 못한 예외 발생 (파일로 기록)

---

### 📝 테스트 방법

1. 서버 실행 후 아래 API 호출:
   * `GET /api/v1/sample/throw-base-exception` → 커스텀 예외 응답 확인
   * `GET /api/v1/sample/throw-unknown-exception` → 내부 서버 오류 발생 및 `/data/logs/` 디렉토리에 로그 파일 생성 확인
2. `data/logs/` 경로 내 에러 로그 파일 생성 여부 확인

---

### ⚡ 기타



