### PR TITLE
OAuth 및 JWT 발급 코드리뷰 피드백 반영

### DIFF
--- a/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/handler/GlobalExceptionHandler.java
@@ -119,32 +119,4 @@ public class GlobalExceptionHandler {
                 .status(errorCode.getStatus())
                 .body(apiResponse);
     }
-
-    /*
-        메서드 보안 전역 처리
-    */
-
-    @ExceptionHandler(AuthenticationException.class)
-    public ResponseEntity<ApiResponse<Void>> handleAuthenticationException(AuthenticationException exception) {
-
-        ErrorCode errorCode = ErrorCode.AUTHENTICATION_FAILED;
-        ApiResponse<Void> apiResponse = ApiResponse.error(errorCode);
-
-        log.warn("AuthenticationException: {}", exception.getMessage());
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(apiResponse);
-    }
-
-    @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<ApiResponse<Void>> handleAccessDeniedException(AccessDeniedException exception) {
-
-        ErrorCode errorCode = ErrorCode.ACCESS_DENIED;
-        ApiResponse<Void> apiResponse = ApiResponse.error(errorCode);
-
-        log.warn("AccessDeniedException: {}", exception.getMessage());
-        return ResponseEntity
-                .status(errorCode.getStatus())
-                .body(apiResponse);
-    }
 }

--- a/src/main/java/com/feelory/feelory_backend/global/security/auth/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/feelory/feelory_backend/global/security/auth/handler/CustomAccessDeniedHandler.java
@@ -3,6 +3,7 @@ package com.feelory.feelory_backend.global.security.auth.handler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.feelory.feelory_backend.global.api.ApiResponse;
 import com.feelory.feelory_backend.global.exception.exceptions.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
@@ -13,10 +14,13 @@ import org.springframework.security.access.AccessDeniedException;
 import java.io.IOException;
 
 @Component
+@Slf4j
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException)
             throws IOException {
+        log.info("권한 없는 사용자 접근 차단 - URI: {}, Method: {}", request.getRequestURI(), request.getMethod());
+
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setContentType("application/json;charset=UTF-8");
 

--- a/src/main/java/com/feelory/feelory_backend/global/security/auth/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/feelory/feelory_backend/global/security/auth/handler/CustomAuthenticationEntryPoint.java
@@ -3,6 +3,7 @@ package com.feelory.feelory_backend.global.security.auth.handler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.feelory.feelory_backend.global.api.ApiResponse;
 import com.feelory.feelory_backend.global.exception.exceptions.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
@@ -12,11 +13,15 @@ import org.springframework.security.core.AuthenticationException;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
             throws IOException {
+        log.info("인증되지 않은 사용자 접근 차단 - URI: {}, Method: {}, Message: {}",
+                request.getRequestURI(), request.getMethod(), authException.getMessage());
+
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json;charset=UTF-8");
 

--- a/src/main/java/com/feelory/feelory_backend/global/security/auth/handler/CustomOAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/feelory/feelory_backend/global/security/auth/handler/CustomOAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,36 @@
+package com.feelory.feelory_backend.global.security.auth.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.feelory.feelory_backend.global.api.ApiResponse;
+import com.feelory.feelory_backend.global.exception.exceptions.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2AuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        log.info("OAuth2 로그인 실패 - URI: {}, Method: {}",
+                request.getRequestURI(), request.getMethod());
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<Void> apiResponse = ApiResponse.error(ErrorCode.AUTHENTICATION_FAILED);
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+}

--- a/src/main/java/com/feelory/feelory_backend/global/security/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/feelory/feelory_backend/global/security/auth/jwt/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package com.feelory.feelory_backend.global.security.auth.jwt;
 
 import com.feelory.feelory_backend.users.model.UserRole;
+import com.feelory.feelory_backend.users.service.UserService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -19,6 +20,7 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class JwtTokenProvider {
     private final JwtProperties jwtProperties;
+    private final UserService userService;
 
     private Key getSigningKey() {
         byte[] keyBytes = Decoders.BASE64.decode(jwtProperties.getSecret());
@@ -50,7 +52,8 @@ public class JwtTokenProvider {
                     .setSigningKey(getSigningKey())
                     .build()
                     .parseClaimsJws(token);
-            return true;
+            Long userId = getUserIdFromToken(token);
+            return userService.isActiveUser(userId);
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }

--- a/src/main/java/com/feelory/feelory_backend/users/repository/UsersRepository.java
+++ b/src/main/java/com/feelory/feelory_backend/users/repository/UsersRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UsersRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByPhoneNumberAndIsActive(String phoneNumber, boolean isActive);
+
+    boolean existsByIdAndIsActiveTrue(Long userId);
 }

--- a/src/main/java/com/feelory/feelory_backend/users/service/UserService.java
+++ b/src/main/java/com/feelory/feelory_backend/users/service/UserService.java
@@ -31,4 +31,8 @@ public class UserService {
                 .isActive(true)
                 .build();
     }
+
+    public boolean isActiveUser(Long userId) {
+        return usersRepository.existsByIdAndIsActiveTrue(userId);
+    }
 }


### PR DESCRIPTION
OAuth2User 대신 OAuth2UserInfo 를 상속 받아서 플랫폼별(카카오, 네이버) 유저 객체로 사용하는 부분은
추후 다른 플랫폼 로그인을 도입할때 추상화하여 리팩토링 하려 합니다.