### PR TITLE
로그아웃 기능 추가 및 전역 예외 처리 메서드 재변경

### DIFF
--- a/src/main/java/com/feelory/feelory_backend/global/api/SuccessCode.java
+++ b/src/main/java/com/feelory/feelory_backend/global/api/SuccessCode.java
@@ -10,6 +10,7 @@ public enum SuccessCode {
     CREATE_KAKAO_LOGIN_URL_SUCCESS("카카오 로그인 URL 생성 완료"),
     LOGIN_KAKAO_SUCCESS("카카오 로그인 성공"),
     REISSUE_TOKENS_SUCCESS("AccessToken 및 RefreshToken 재발급 성공"),
+    LOGOUT_SUCCESS("로그아웃 성공"),
 
     // USERS(사용자)
 

--- a/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/handler/GlobalExceptionHandler.java
@@ -119,4 +119,19 @@ public class GlobalExceptionHandler {
                 .status(errorCode.getStatus())
                 .body(apiResponse);
     }
+    /*
+        메서드 보안 전역 처리
+    */
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAccessDeniedException(AccessDeniedException exception) {
+
+        ErrorCode errorCode = ErrorCode.ACCESS_DENIED;
+        ApiResponse<Void> apiResponse = ApiResponse.error(errorCode);
+
+        log.warn("AccessDeniedException: {}", exception.getMessage());
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(apiResponse);
+    }
 }

--- a/src/main/java/com/feelory/feelory_backend/global/security/auth/controller/AuthController.java
+++ b/src/main/java/com/feelory/feelory_backend/global/security/auth/controller/AuthController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,6 +30,7 @@ public class AuthController {
             security = {@SecurityRequirement(name = "JWT")}
     )
     @PostMapping("/refresh-token")
+    @PreAuthorize("hasRole('USER')")
     public ApiResponse<RefreshTokenResponse> reissueToken(@RequestBody RefreshTokenRequest request) {
 
         RefreshTokenResponse refreshTokenResponse = authService.reissueToken(request);
@@ -42,6 +44,7 @@ public class AuthController {
             security = {@SecurityRequirement(name = "JWT")}
     )
     @PostMapping("/logout")
+    @PreAuthorize("hasRole('USER')")
     public ApiResponse<Void> logout(@RequestBody LogoutRequest request) {
 
         authService.logout(request);

--- a/src/main/java/com/feelory/feelory_backend/global/security/auth/controller/AuthController.java
+++ b/src/main/java/com/feelory/feelory_backend/global/security/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.feelory.feelory_backend.global.security.auth.controller;
 
 import com.feelory.feelory_backend.global.api.ApiResponse;
 import com.feelory.feelory_backend.global.api.SuccessCode;
+import com.feelory.feelory_backend.global.security.auth.dto.request.LogoutRequest;
 import com.feelory.feelory_backend.global.security.auth.service.AuthService;
 import com.feelory.feelory_backend.users.model.request.RefreshTokenRequest;
 import com.feelory.feelory_backend.users.model.response.RefreshTokenResponse;
@@ -33,5 +34,17 @@ public class AuthController {
         RefreshTokenResponse refreshTokenResponse = authService.reissueToken(request);
 
         return ApiResponse.success(refreshTokenResponse, SuccessCode.REISSUE_TOKENS_SUCCESS);
+    }
+
+    @Operation(
+            summary = "로그아웃 API",
+            description = "해당 요청시 DB의 RefreshToken을 폐기합니다.",
+            security = {@SecurityRequirement(name = "JWT")}
+    )
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(@RequestBody LogoutRequest request) {
+
+        authService.logout(request);
+        return ApiResponse.success(null, SuccessCode.LOGOUT_SUCCESS);
     }
 }

--- a/src/main/java/com/feelory/feelory_backend/global/security/auth/dto/request/LogoutRequest.java
+++ b/src/main/java/com/feelory/feelory_backend/global/security/auth/dto/request/LogoutRequest.java
@@ -1,0 +1,16 @@
+package com.feelory.feelory_backend.global.security.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LogoutRequest {
+    @NotBlank(message = "RefreshToken 값은 필수입니다.")
+    private String refreshToken;
+}

--- a/src/main/java/com/feelory/feelory_backend/global/security/auth/service/AuthService.java
+++ b/src/main/java/com/feelory/feelory_backend/global/security/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.feelory.feelory_backend.global.security.auth.service;
 
 import com.feelory.feelory_backend.global.exception.exceptions.users.InvalidPhoneNumberException;
+import com.feelory.feelory_backend.global.security.auth.dto.request.LogoutRequest;
 import com.feelory.feelory_backend.global.security.auth.dto.response.LoginResponse;
 import com.feelory.feelory_backend.global.security.auth.jwt.JwtTokenProvider;
 import com.feelory.feelory_backend.users.entity.UserTokens;
@@ -74,6 +75,13 @@ public class AuthService {
                 .refreshToken(newRefreshToken)
                 .refreshTokenExpireAt(newRefreshTokenExp)
                 .build();
+    }
+
+    @Transactional
+    public void logout(LogoutRequest request) {
+        UserTokens currentUserToken= userTokenService.findRefreshToken(request.getRefreshToken());
+
+        userTokenService.deactivateRefreshToken(currentUserToken);
     }
 
     private String formatPhoneNumber(String phoneNumber) {

--- a/src/main/java/com/feelory/feelory_backend/users/service/UserTokenService.java
+++ b/src/main/java/com/feelory/feelory_backend/users/service/UserTokenService.java
@@ -52,4 +52,8 @@
 
             userTokensRepository.save(newToken);
         }
+
+        public void deactivateRefreshToken(UserTokens refreshToken) {
+            refreshToken.deactivate();
+        }
     }


### PR DESCRIPTION
### ✨ 작업 개요
- 로그아웃 기능 추가
- 전역 예외 처리 메서드 변경

---

### 🔧 변경사항

* **`AuthController.java`**
  * `POST /auth/logout` API 추가
    * JWT 인증이 필요한 로그아웃 요청 처리
    * `@PreAuthorize("hasRole('USER')")` 어노테이션으로 권한 체크 추가
  * 기존 `reissueToken()` 메서드에도 누락된 `@PreAuthorize("hasRole('USER')")` 추가

* **`UserTokenService.java`**
  * `deactivateRefreshToken()` 메서드 추가
    * 토큰 객체의 `deactivate()` 메서드 호출

* **`GlobalExceptionHandler.java`**
  * `AccessDeniedException` 처리 핸들러 재 추가

---

### 📝 테스트 방법

1. 로그인 및 토큰 발급 후, 헤더 JWT 첨부와 함꼐 아래 API 호출
    * `POST /api/v1/auth/logout`
    * Body: `{ "refreshToken": "<발급받은 refreshToken>" }`
2. 응답으로 `로그아웃 성공` 메시지와 함께 200 OK 반환
3. 동일한 RefreshToken 사용 시 재사용 불가 및 DB에서 비활성 확인

---

### ⚡ 기타

* **먼저, 전역 예외 처리 관련하여 여러번 혼란을 여러번 드려 죄송합니다.**
* `@PreAuthorize` 가 스프링 AOP 기반이라 DispatcherServlet 이후, Controller 메서드 호출 전에 동작하네요. 당시 수정된 코드리뷰 답글을 작성할 당시 정신이 없었습니다.
* 실제로도 예외 핸들러를 추가하지 않으면 해당 핸들러에서 지정하지 않은 500에러로 받고 있었기 때문에 추가할 필요가 있었네요.
* 다만 인증 메서드는 필요 없어 보입니다. 그래서 인가 메서드만 추가했습니다.
* 작업 양이 많지않아 해당 PR 또한 바로 병합한후 프로필 작업 해보려 합니다.