### PR TITLE
Gemini 응답 시 JSON 객체로 파싱하는 기능 구현

### DIFF
--- a/src/main/java/com/feelory/feelory_backend/domain/feedback/model/response/FeedbackResponse.java
+++ b/src/main/java/com/feelory/feelory_backend/domain/feedback/model/response/FeedbackResponse.java
@@ -1,5 +1,6 @@
 package com.feelory.feelory_backend.domain.feedback.model.response;
 
+import com.feelory.feelory_backend.global.webclient.dto.model.GeminiFeedbackForm;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,5 +11,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class FeedbackResponse {
+    private Integer score;
     private String content;
+
+    public static FeedbackResponse fromForm(GeminiFeedbackForm form) {
+
+        return new FeedbackResponse(form.getScore(), form.getContent());
+    }
 }

--- a/src/main/java/com/feelory/feelory_backend/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/feelory/feelory_backend/domain/feedback/service/FeedbackService.java
@@ -1,11 +1,16 @@
 package com.feelory.feelory_backend.domain.feedback.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.feelory.feelory_backend.domain.feedback.entity.Feedback;
 import com.feelory.feelory_backend.domain.feedback.model.request.FeedbackRequest;
 import com.feelory.feelory_backend.domain.feedback.model.response.FeedbackResponse;
 import com.feelory.feelory_backend.domain.feedback.repository.FeedbackRepository;
+import com.feelory.feelory_backend.global.exception.exceptions.feedback.FeedbackParsingException;
 import com.feelory.feelory_backend.global.exception.exceptions.writing.WritingNotFoundException;
 import com.feelory.feelory_backend.global.webclient.GenerateContent;
+import com.feelory.feelory_backend.global.webclient.dto.model.GeminiFeedbackForm;
 import com.feelory.feelory_backend.global.webclient.dto.request.GenerateContentRequest;
 import com.feelory.feelory_backend.global.webclient.dto.reponse.GenerateContentResponse;
 import com.feelory.feelory_backend.domain.writing.entity.DailyWordWriting;
@@ -30,11 +35,13 @@ public class FeedbackService {
 
         GenerateContentResponse feedbackResponse = generateContentFromModel(feedbackRequest);
 
-        String feedbackText = extractFeedbackText(feedbackResponse);
+        String feedbackJson = extractFeedbackText(feedbackResponse);
 
-        saveFeedback(feedbackText, writing);
+        GeminiFeedbackForm form = parsingFeedbackForm(feedbackJson);
 
-        return new FeedbackResponse(feedbackText);
+        saveFeedback(feedbackJson, writing);
+
+        return FeedbackResponse.fromForm(form);
     }
 
     private DailyWordWriting findDailyWriting(FeedbackRequest request) {
@@ -69,4 +76,17 @@ public class FeedbackService {
         feedbackRepository.save(newFeedback);
     }
 
+    private GeminiFeedbackForm parsingFeedbackForm(String json) {
+
+        ObjectMapper om = new ObjectMapper()
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        try {
+
+            return om.readValue(json, GeminiFeedbackForm.class);
+        } catch (JsonProcessingException e) {
+
+            throw new FeedbackParsingException();
+        }
+    }
 }

--- a/src/main/java/com/feelory/feelory_backend/global/exception/dto/model/ErrorCode.java
+++ b/src/main/java/com/feelory/feelory_backend/global/exception/dto/model/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     // E5XX : FEEDBACK(피드백)
     GENERATE_CONTENT_FAILED(HttpStatus.BAD_GATEWAY, "E500", "외부 API 피드백 생성 요청이 실패했습니다."),
     EXTERNAL_API_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "E501", "외부 API 서버와의 연결에 실패했습니다."),
+    FEEDBACK_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "E502", "LLM으로 부터 받은 피드백 파싱에 실패했습니다."),
 
     // E6XX : FILE (파일)
     FILE_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "E900", "파일이 제공되지 않았습니다."),

--- a/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/feedback/FeedbackParsingException.java
+++ b/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/feedback/FeedbackParsingException.java
@@ -1,0 +1,10 @@
+package com.feelory.feelory_backend.global.exception.exceptions.feedback;
+
+import com.feelory.feelory_backend.global.exception.dto.model.ErrorCode;
+import com.feelory.feelory_backend.global.exception.exceptions.BaseException;
+
+public class FeedbackParsingException extends BaseException {
+    public FeedbackParsingException() {
+        super(ErrorCode.FEEDBACK_PARSING_FAILED);
+    }
+}

--- a/src/main/java/com/feelory/feelory_backend/global/util/GeminiFeedbackSchemaMapper.java
+++ b/src/main/java/com/feelory/feelory_backend/global/util/GeminiFeedbackSchemaMapper.java
@@ -1,0 +1,126 @@
+package com.feelory.feelory_backend.global.util;
+
+import com.feelory.feelory_backend.global.webclient.dto.model.GeminiFeedbackForm;
+import com.feelory.feelory_backend.global.webclient.annotation.GeminiFeedbackProperty;
+import com.feelory.feelory_backend.global.webclient.dto.model.GeminiResponseType;
+import com.feelory.feelory_backend.global.webclient.dto.request.GenerateContentRequest;
+import lombok.NoArgsConstructor;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+@NoArgsConstructor
+public class GeminiFeedbackSchemaMapper {
+
+    // 외부 공개: 캐시된 스키마만 반환
+    public static GenerateContentRequest.Schema schema() {
+        return Holder.SCHEMA;
+    }
+
+    // 실제 빌드는 한 번만
+    private static GenerateContentRequest.Schema buildOnce() {
+
+        List<Field> annotated = collectAnnotatedFields(GeminiFeedbackForm.class);
+
+        sortByOrder(annotated);
+
+        BuildContext ctx = buildProperties(annotated);
+
+        return buildSchema(ctx);
+    }
+
+    // --- 동작 분리 ---
+
+    // 어노테이션이 붙은 필드 추출
+    private static List<Field> collectAnnotatedFields(Class<?> target) {
+        Field[] fields = target.getDeclaredFields();
+        List<Field> annotated = new ArrayList<>();
+
+        for (Field f : fields) {
+
+            // isSynthetic => 컴파일러가 내부용으로 만든 어노테이션인지 여부
+            // isAnnotationPresent => 해당 필드에 GeminiFeedbackProperty 어노테이션이 붙어있는지 여부
+
+            if (!f.isSynthetic() && f.isAnnotationPresent(GeminiFeedbackProperty.class)) {
+                annotated.add(f);
+            }
+        }
+
+        return annotated;
+    }
+
+    // order에 따른 순서 정렬
+    private static void sortByOrder(List<Field> fields) {
+        fields.sort(Comparator.comparingInt(f ->
+                f.getAnnotation(GeminiFeedbackProperty.class).order()));
+    }
+
+    // 중간 산출물 생성
+    private static BuildContext buildProperties(List<Field> fields) {
+        // 필드를 삽입한 순서를 기억해야하므로 LinkedHashMap 사용
+        Map<String, GenerateContentRequest.Property> properties = new LinkedHashMap<>();
+        List<String> ordering = new ArrayList<>();
+        List<String> required = new ArrayList<>();
+
+        for (Field f : fields) {
+            GeminiFeedbackProperty meta = f.getAnnotation(GeminiFeedbackProperty.class);
+            String key = meta.name().isEmpty() ? f.getName() : meta.name();
+
+            properties.put(key, toProperty(meta));
+            ordering.add(key);
+            if (meta.required()) required.add(key);
+        }
+        return new BuildContext(properties, ordering, required);
+    }
+
+    // GenerateContentRequest.Property 객체로 변환
+    private static GenerateContentRequest.Property toProperty(GeminiFeedbackProperty meta) {
+        List<String> enums = meta.enumValues().length == 0
+                ? null
+                : Arrays.asList(meta.enumValues());
+        return new GenerateContentRequest.Property(meta.type(), meta.description(), enums);
+    }
+
+    // 최종 산출물로 변환
+    private static GenerateContentRequest.Schema buildSchema(BuildContext ctx) {
+
+        /*
+            - 현재 Schema 생성 방식 -> 캐싱을 통한 하나의 Schema를 공유하고 있음 (메모리 효율성을 위하여)
+            - 여러 쓰레드가 공유하게 되므로 한쪽에서 임의적으로 변경하지 못하도록 불변으로 return 해야 함
+            - unmodifiableMap()은 불변 뷰를 return함
+            - 뷰를 대상으로 put, remove 등의 수정은 불가능함
+        */
+        Map<String, GenerateContentRequest.Property> propsFinal = Collections.unmodifiableMap(ctx.properties);
+
+        List<String> orderingFinal = ctx.ordering.isEmpty() ? null : List.copyOf(ctx.ordering);
+        List<String> requiredFinal = ctx.required.isEmpty() ? null : List.copyOf(ctx.required);
+
+        return new GenerateContentRequest.Schema(
+                GeminiResponseType.OBJECT,
+                false,
+                propsFinal,
+                orderingFinal,
+                requiredFinal
+        );
+    }
+
+    // 중간 산출물 컨텍스트
+    private static final class BuildContext {
+        final Map<String, GenerateContentRequest.Property> properties;
+        final List<String> ordering;
+        final List<String> required;
+
+        BuildContext(Map<String, GenerateContentRequest.Property> properties,
+                     List<String> ordering,
+                     List<String> required) {
+            this.properties = properties;
+            this.ordering = ordering;
+            this.required = required;
+        }
+    }
+
+    // 지연 초기화 + 스레드 안전 캐시
+    private static final class Holder {
+        private static final GenerateContentRequest.Schema SCHEMA = buildOnce();
+    }
+}

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/annotation/GeminiFeedbackProperty.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/annotation/GeminiFeedbackProperty.java
@@ -1,0 +1,19 @@
+package com.feelory.feelory_backend.global.webclient.annotation;
+
+import com.feelory.feelory_backend.global.webclient.dto.model.GeminiPropertyType;
+import java.lang.annotation.*;
+
+/*
+    Gemini responseSchema/응답 JSON 생성을 위한 필드 메타데이터.
+*/
+
+@Retention(RetentionPolicy.RUNTIME)         // 리플렉션 통해서 메타데이터 추출하기 위해 사용
+@Target(ElementType.FIELD)
+public @interface GeminiFeedbackProperty {
+    GeminiPropertyType type();              // 프로퍼티 자료형
+    String description() default "";        // 필드 설명(LLM 안내용, 설정용)
+    int order() default Integer.MAX_VALUE;  // 출력 순서(작을수록 먼저)
+    boolean required() default true;        // 필수 필드 여부
+    String[] enumValues() default {};       // 사용할 ENUM 목록 (주로 GeminiPropertyType.STRING 일 때 사용 가능)
+    String name() default "";               // JSON 키(미지정 시 필드명 사용)
+}

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/annotation/GeminiFeedbackProperty.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/annotation/GeminiFeedbackProperty.java
@@ -5,6 +5,7 @@ import java.lang.annotation.*;
 
 /*
     Gemini responseSchema/응답 JSON 생성을 위한 필드 메타데이터.
+    참고 : https://ai.google.dev/api/caching?hl=ko#Schema
 */
 
 @Retention(RetentionPolicy.RUNTIME)         // 리플렉션 통해서 메타데이터 추출하기 위해 사용
@@ -16,4 +17,8 @@ public @interface GeminiFeedbackProperty {
     boolean required() default true;        // 필수 필드 여부
     String[] enumValues() default {};       // 사용할 ENUM 목록 (주로 GeminiPropertyType.STRING 일 때 사용 가능)
     String name() default "";               // JSON 키(미지정 시 필드명 사용)
+    int minLength();                        // GeminiPropertyType.STRING 일 때 최소 길이
+    int maxLength();                        // GeminiPropertyType.STRING 일 때 최대 길이
+    int minimum();                          // GeminiPropertyType.INTEGER 일 때 최솟값
+    int maximum();                          // GeminiPropertyType.INTEGER 일 때 최댓값
 }

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/annotation/GeminiFeedbackProperty.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/annotation/GeminiFeedbackProperty.java
@@ -8,17 +8,17 @@ import java.lang.annotation.*;
     참고 : https://ai.google.dev/api/caching?hl=ko#Schema
 */
 
-@Retention(RetentionPolicy.RUNTIME)         // 리플렉션 통해서 메타데이터 추출하기 위해 사용
+@Retention(RetentionPolicy.RUNTIME)                 // 리플렉션 통해서 메타데이터 추출하기 위해 사용
 @Target(ElementType.FIELD)
 public @interface GeminiFeedbackProperty {
-    GeminiPropertyType type();              // 프로퍼티 자료형
-    String description() default "";        // 필드 설명(LLM 안내용, 설정용)
-    int order() default Integer.MAX_VALUE;  // 출력 순서(작을수록 먼저)
-    boolean required() default true;        // 필수 필드 여부
-    String[] enumValues() default {};       // 사용할 ENUM 목록 (주로 GeminiPropertyType.STRING 일 때 사용 가능)
-    String name() default "";               // JSON 키(미지정 시 필드명 사용)
-    int minLength();                        // GeminiPropertyType.STRING 일 때 최소 길이
-    int maxLength();                        // GeminiPropertyType.STRING 일 때 최대 길이
-    int minimum();                          // GeminiPropertyType.INTEGER 일 때 최솟값
-    int maximum();                          // GeminiPropertyType.INTEGER 일 때 최댓값
+    GeminiPropertyType type();                      // 프로퍼티 자료형
+    String description() default "";                // 필드 설명(LLM 안내용, 설정용)
+    int order() default Integer.MAX_VALUE;          // 출력 순서(작을수록 먼저)
+    boolean required() default true;                // 필수 필드 여부
+    String[] enumValues() default {};               // 사용할 ENUM 목록 (주로 GeminiPropertyType.STRING 일 때 사용 가능)
+    String name() default "";                       // JSON 키(미지정 시 필드명 사용)
+    int minLength() default 0;                      // GeminiPropertyType.STRING 일 때 최소 길이
+    int maxLength() default 5000;                   // GeminiPropertyType.STRING 일 때 최대 길이
+    int minimum() default 0;                        // GeminiPropertyType.INTEGER 일 때 최솟값
+    int maximum() default Integer.MAX_VALUE;        // GeminiPropertyType.INTEGER 일 때 최댓값
 }

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiBlockReason.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiBlockReason.java
@@ -1,0 +1,22 @@
+package com.feelory.feelory_backend.global.webclient.dto.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+/*
+    참고 : https://ai.google.dev/api/generate-content?hl=ko#BlockReason
+*/
+@Getter
+@ToString
+@RequiredArgsConstructor
+public enum GeminiBlockReason {
+    BLOCK_REASON_UNSPECIFIED("기본값 이 값은 사용되지 않습니다."),
+    SAFETY("안전상의 이유로 프롬프트가 차단되었습니다. safetyRatings를 검사하여 차단한 안전 카테고리를 파악합니다."),
+    OTHER("알 수 없는 이유로 프롬프트가 차단되었습니다."),
+    BLOCKLIST("용어 차단 목록에 포함된 용어로 인해 프롬프트가 차단되었습니다."),
+    PROHIBITED_CONTENT("금지된 콘텐츠로 인해 프롬프트가 차단되었습니다."),
+    IMAGE_SAFETY("안전하지 않은 이미지 생성 콘텐츠로 인해 후보자가 차단되었습니다.");
+
+    private final String description;
+}

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiFeedbackForm.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiFeedbackForm.java
@@ -23,7 +23,9 @@ public class GeminiFeedbackForm {
             type = GeminiPropertyType.INTEGER,
             description = "평가 점수. 10점 만점 중 몇 점인지 (예: 2)",
             order = 1,
-            name = "score"
+            name = "score",
+            minimum = 0,
+            maximum = 10
     )
     private Integer score;
 
@@ -31,7 +33,9 @@ public class GeminiFeedbackForm {
             type = GeminiPropertyType.STRING,
             description = "피드백 내용",
             order = 2,
-            name = "content"
+            name = "content",
+            minLength = 30,
+            maxLength = 5000
     )
     private String content;
 }

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiFeedbackForm.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiFeedbackForm.java
@@ -1,0 +1,37 @@
+package com.feelory.feelory_backend.global.webclient.dto.model;
+
+import com.feelory.feelory_backend.global.webclient.annotation.GeminiFeedbackProperty;
+import lombok.*;
+
+/**
+ * Gemini가 JSON으로 반환해야 하는 피드백 계약 모델.
+ * - @GeminiFeedbackProperty 메타데이터로 responseSchema(properties/required/order) 생성
+ * - LLM 응답(JSON) 역직렬화 대상 (score, content 키 기준)
+ *
+ * 예시 JSON:
+ * { "score": 2, "content": "간단한 피드백 본문" }
+ */
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GeminiFeedbackForm {
+
+    @GeminiFeedbackProperty(
+            type = GeminiPropertyType.INTEGER,
+            description = "평가 점수. 10점 만점 중 몇 점인지 (예: 2)",
+            order = 1,
+            name = "score"
+    )
+    private Integer score;
+
+    @GeminiFeedbackProperty(
+            type = GeminiPropertyType.STRING,
+            description = "피드백 내용",
+            order = 2,
+            name = "content"
+    )
+    private String content;
+}

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiFinishReason.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiFinishReason.java
@@ -4,6 +4,9 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
+/*
+    참고 : https://ai.google.dev/api/generate-content?hl=ko#FinishReason
+*/
 @Getter
 @ToString
 @RequiredArgsConstructor

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiFinishReason.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiFinishReason.java
@@ -1,0 +1,26 @@
+package com.feelory.feelory_backend.global.webclient.dto.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@RequiredArgsConstructor
+public enum GeminiFinishReason {
+    FINISH_REASON_UNSPECIFIED("기본값 이 값은 사용되지 않습니다."),
+    STOP("모델의 자연 중단 지점 또는 중지 시퀀스가 제공됩니다."), // 토큰 출력 성공 시 기본값
+    MAX_TOKENS("요청에 지정된 최대 토큰 수에 도달했습니다."),
+    SAFETY("안전상의 이유로 응답 후보 콘텐츠가 신고되었습니다."),
+    RECITATION("응답 후보 콘텐츠가 암송 이유로 신고되었습니다."),
+    LANGUAGE("지원되지 않는 언어를 사용한 것으로 응답 후보 콘텐츠가 신고되었습니다."),
+    OTHER("알 수 없는 이유입니다."),
+    BLOCKLIST("콘텐츠에 금지된 용어가 포함되어 있어 토큰 생성이 중지되었습니다."),
+    PROHIBITED_CONTENT("금지된 콘텐츠가 포함되어 있을 수 있어 토큰 생성이 중지되었습니다."),
+    SPII("콘텐츠에 민감한 개인 식별 정보 (SPII)가 포함되어 있을 수 있으므로 토큰 생성이 중지되었습니다."),
+    MALFORMED_FUNCTION_CALL("모델에서 생성된 함수 호출이 잘못되었습니다."),
+    IMAGE_SAFETY("생성된 이미지에 안전 위반이 포함되어 있어 토큰 생성이 중지되었습니다."),
+    UNEXPECTED_TOOL_CALL("모델이 도구 호출을 생성했지만 요청에서 사용 설정된 도구가 없습니다.");
+
+    private final String description;
+}

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiHarmBlockThreshold.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiHarmBlockThreshold.java
@@ -1,0 +1,24 @@
+package com.feelory.feelory_backend.global.webclient.dto.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+/*
+    참고 : https://ai.google.dev/api/generate-content?hl=ko#HarmBlockThreshold
+*/
+@Getter
+@ToString
+@RequiredArgsConstructor
+public enum GeminiHarmBlockThreshold {
+
+    HARM_BLOCK_THRESHOLD_UNSPECIFIED("기준점이 지정되지 않았습니다."),
+    BLOCK_LOW_AND_ABOVE("무시할 수 있는 콘텐츠는 허용됩니다."),
+    BLOCK_MEDIUM_AND_ABOVE("무시할 수 있는 수준 및 낮음 콘텐츠는 허용됩니다."),
+    BLOCK_ONLY_HIGH("'무시할 수 있음', '낮음', '중간' 콘텐츠는 허용됩니다.");
+    
+    /* 권고되지 않음 */
+//    BLOCK_NONE("모든 콘텐츠가 허용됩니다."),
+//    OFF("안전 필터를 사용 중지합니다.");
+
+    private final String description;
+}

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiHarmCategory.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiHarmCategory.java
@@ -10,7 +10,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @RequiredArgsConstructor
-public enum GeminiSafetyCategory {
+public enum GeminiHarmCategory {
     HARM_CATEGORY_UNSPECIFIED("카테고리가 지정되지 않았습니다."),
     HARM_CATEGORY_DEROGATORY("PaLM - ID 또는 보호 속성을 대상으로 하는 부정적이거나 유해한 댓글"),
     HARM_CATEGORY_TOXICITY("PaLM - 무례하거나 모욕적이거나 욕설이 있는 콘텐츠"),

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiHarmProbability.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiHarmProbability.java
@@ -1,0 +1,22 @@
+package com.feelory.feelory_backend.global.webclient.dto.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+/*
+    참고 : https://ai.google.dev/api/generate-content?hl=ko#HarmProbability
+*/
+@Getter
+@ToString
+@RequiredArgsConstructor
+public enum GeminiHarmProbability {
+
+    HARM_PROBABILITY_UNSPECIFIED("확률이 지정되지 않았습니다."),
+    NEGLIGIBLE("콘텐츠가 안전하지 않을 가능성은 무시할 만합니다."),
+    LOW("콘텐츠는 안전하지 않을 가능성이 낮습니다."),
+    MEDIUM("콘텐츠가 안전하지 않을 가능성이 중간 정도입니다."),
+    HIGH("콘텐츠가 안전하지 않을 가능성이 높습니다.");
+
+    private final String description;
+}

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiPropertyType.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiPropertyType.java
@@ -1,0 +1,6 @@
+package com.feelory.feelory_backend.global.webclient.dto.model;
+
+public enum GeminiPropertyType {
+    STRING,
+    INTEGER
+}

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiResponseType.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiResponseType.java
@@ -1,0 +1,12 @@
+package com.feelory.feelory_backend.global.webclient.dto.model;
+
+public enum GeminiResponseType {
+    TYPE_UNSPECIFIED,
+    STRING,
+    NUMBER,
+    INTEGER,
+    BOOLEAN,
+    ARRAY,
+    OBJECT,
+    NULL
+}

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiSafetyCategory.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/model/GeminiSafetyCategory.java
@@ -1,0 +1,27 @@
+package com.feelory.feelory_backend.global.webclient.dto.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+/*
+    참고 : https://ai.google.dev/api/generate-content?hl=ko#v1beta.HarmCategory
+*/
+@Getter
+@ToString
+@RequiredArgsConstructor
+public enum GeminiSafetyCategory {
+    HARM_CATEGORY_UNSPECIFIED("카테고리가 지정되지 않았습니다."),
+    HARM_CATEGORY_DEROGATORY("PaLM - ID 또는 보호 속성을 대상으로 하는 부정적이거나 유해한 댓글"),
+    HARM_CATEGORY_TOXICITY("PaLM - 무례하거나 모욕적이거나 욕설이 있는 콘텐츠"),
+    HARM_CATEGORY_VIOLENCE("PaLM - 개인 또는 그룹에 대한 폭력을 묘사하는 시나리오 또는 유혈 콘텐츠에 대한 일반적인 설명을 묘사합니다."),
+    HARM_CATEGORY_SEXUAL("PaLM - 성행위 또는 기타 외설적인 콘텐츠에 대한 참조가 포함되어 있습니다."),
+    HARM_CATEGORY_MEDICAL("PaLM - 확인되지 않은 의학적 조언을 홍보합니다."),
+    HARM_CATEGORY_DANGEROUS("PaLM - 유해한 행위를 조장, 촉진 또는 장려하는 위험한 콘텐츠입니다."),
+    HARM_CATEGORY_HARASSMENT("Gemini - 괴롭힘 콘텐츠"),
+    HARM_CATEGORY_HATE_SPEECH("Gemini - 증오심 표현 및 콘텐츠"),
+    HARM_CATEGORY_SEXUALLY_EXPLICIT("Gemini - 음란물"),
+    HARM_CATEGORY_DANGEROUS_CONTENT("Gemini - 위험한 콘텐츠");
+
+    private final String description;
+}

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/reponse/GenerateContentResponse.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/reponse/GenerateContentResponse.java
@@ -1,16 +1,24 @@
 package com.feelory.feelory_backend.global.webclient.dto.reponse;
 
+import com.feelory.feelory_backend.global.webclient.dto.model.GeminiBlockReason;
+import com.feelory.feelory_backend.global.webclient.dto.model.GeminiFinishReason;
+import com.feelory.feelory_backend.global.webclient.dto.model.GeminiHarmCategory;
+import com.feelory.feelory_backend.global.webclient.dto.model.GeminiHarmProbability;
+
 import java.util.List;
 
 public class GenerateContentResponse {
     public List<Candidate> candidates;
 //    public UsageMetadata usageMetadata;
-//    public String modelVersion;
-//    public String responseId;
+    public PromptFeedback promptFeedback;               // 프롬프트 전체에 대한 안전 등급
+    public String modelVersion;                         // 로깅 목적의 사용한 모델 버전
+    public String responseId;                           // 로깅 목적의 LLM 응답의 고유 ID (지원팀 제공용)
 
     public static class Candidate {
         public Content content;
-//        public String finishReason;
+        public GeminiFinishReason finishReason;             // 토큰 생성 중단 사유
+        public List<SafetyRating> safetyRatings;            // 응답 후보군 별 안전 등급
+        public Integer tokenCount;                          // 해당 후보의 토큰 수
 //        public int index;
 
         public static class Content {
@@ -22,6 +30,12 @@ public class GenerateContentResponse {
             }
         }
     }
+
+    public static class PromptFeedback {
+        public GeminiBlockReason blockReason;           // 프롬프트가 차단되었을 시 사유
+        public List<SafetyRating> safetyRatings;
+    }
+
 
 //    public static class UsageMetadata {
 //        public int promptTokenCount;
@@ -36,4 +50,12 @@ public class GenerateContentResponse {
 //
 //        public Integer thoughtsTokenCount;
 //    }
+
+    public static class SafetyRating {
+        public GeminiHarmCategory category;         // 유해 콘텐츠 유형
+        public GeminiHarmProbability probability;   // 해당 카테고리 기준으로 유해 콘텐츠일 확률
+        public boolean blocked;                     // 해당 값으로 응답 필터링 여부를 확인할 수 있습니다.
+                                                    // 후보군 중 blocked가 있는 항목을 제외하고 응답을 선택하는 식으로 활용할 수 있습니다.
+    }
+
 }

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/request/GenerateContentRequest.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/request/GenerateContentRequest.java
@@ -5,7 +5,7 @@ import com.feelory.feelory_backend.global.util.GeminiFeedbackSchemaMapper;
 import com.feelory.feelory_backend.global.webclient.dto.model.GeminiHarmBlockThreshold;
 import com.feelory.feelory_backend.global.webclient.dto.model.GeminiPropertyType;
 import com.feelory.feelory_backend.global.webclient.dto.model.GeminiResponseType;
-import com.feelory.feelory_backend.global.webclient.dto.model.GeminiSafetyCategory;
+import com.feelory.feelory_backend.global.webclient.dto.model.GeminiHarmCategory;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.*;
@@ -121,7 +121,7 @@ public class GenerateContentRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SafetySetting {
-        private GeminiSafetyCategory category;
+        private GeminiHarmCategory category;
         private GeminiHarmBlockThreshold threshold;
     }
 

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/request/GenerateContentRequest.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/request/GenerateContentRequest.java
@@ -68,7 +68,7 @@ import java.util.Map;
 @AllArgsConstructor
 public class GenerateContentRequest {
     private List<Content> contents;
-    private SystemInstruction systemInstruction;
+    private Content systemInstruction;
     private String cachedContent;
     private List<Tool> tools;
     private List<SafetySetting> safetySettings;
@@ -89,15 +89,6 @@ public class GenerateContentRequest {
     @AllArgsConstructor
     public static class Part {
         private String text;
-    }
-
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class SystemInstruction {
-        private String role;
-        private List<Part> parts;
     }
 
     @Getter
@@ -171,7 +162,8 @@ public class GenerateContentRequest {
         Part personaPart = new Part("너는 이용자의 글을 읽고 평가해야하는 피드백을 주는 평가자야.");
         Part cmdPart = new Part("이용자의 글을 객관적이고 냉소적으로 평가해줘.");
 
-        SystemInstruction systemInstruction = new SystemInstruction(
+        // SystemInstruction의 role 필드는 무시된다고 하니 참고바랍니다.
+        Content systemInstruction = new Content(
                 "system",
                 List.of(
                         personaPart,

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/request/GenerateContentRequest.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/request/GenerateContentRequest.java
@@ -2,8 +2,10 @@ package com.feelory.feelory_backend.global.webclient.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.feelory.feelory_backend.global.util.GeminiFeedbackSchemaMapper;
+import com.feelory.feelory_backend.global.webclient.dto.model.GeminiHarmBlockThreshold;
 import com.feelory.feelory_backend.global.webclient.dto.model.GeminiPropertyType;
 import com.feelory.feelory_backend.global.webclient.dto.model.GeminiResponseType;
+import com.feelory.feelory_backend.global.webclient.dto.model.GeminiSafetyCategory;
 import lombok.*;
 
 import java.util.List;
@@ -109,13 +111,16 @@ public class GenerateContentRequest {
         private Map<String, Object> parameters;
     }
 
+    /*
+        특정 유해 카테고리의 필터링 수준을 조절 가능한 옵션
+    */
     @Getter
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SafetySetting {
-        private String category;
-        private String threshold;
+        private GeminiSafetyCategory category;
+        private GeminiHarmBlockThreshold threshold;
     }
 
     @Getter

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/request/GenerateContentRequest.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/request/GenerateContentRequest.java
@@ -1,5 +1,9 @@
 package com.feelory.feelory_backend.global.webclient.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.feelory.feelory_backend.global.util.GeminiFeedbackSchemaMapper;
+import com.feelory.feelory_backend.global.webclient.dto.model.GeminiPropertyType;
+import com.feelory.feelory_backend.global.webclient.dto.model.GeminiResponseType;
 import lombok.*;
 
 import java.util.List;
@@ -133,15 +137,58 @@ public class GenerateContentRequest {
         private Double topP;
         private Integer maxOutputTokens;
         private String responseMimeType;
-        private Map<String, Object> responseSchema;
+        private Schema responseSchema;
+    }
+
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Schema {
+        private GeminiResponseType type;
+        private boolean nullable;
+        private Map<String, Property> properties;
+        private List<String> propertyOrdering;
+        private List<String> required;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Property {
+        private GeminiPropertyType type;
+        private String description;
+        @JsonProperty("enum")
+        private List<String> enumValue;
     }
 
     public static GenerateContentRequest ofText(String text) {
         Part part = new Part(text);
         Content content = new Content("user", List.of(part));
 
-        Part sysPart = new Part("이용자의 글을 객관적이고 냉소적으로 평가해줘. 맨 앞줄에 '점수 : (N/10)' 로 점수를 먼저 매기고 평가를 남겨줘.");
-        SystemInstruction systemInstruction = new SystemInstruction("system", List.of(sysPart));
+        Part personaPart = new Part("너는 이용자의 글을 읽고 평가해야하는 피드백을 주는 평가자야.");
+        Part cmdPart = new Part("이용자의 글을 객관적이고 냉소적으로 평가해줘.");
+
+        SystemInstruction systemInstruction = new SystemInstruction(
+                "system",
+                List.of(
+                        personaPart,
+                        cmdPart
+                )
+        );
+
+        Schema schema = GeminiFeedbackSchemaMapper.schema();
+
+        GenerationConfig generationConfig = new GenerationConfig(
+                null,
+                null,
+                null,
+                null,
+                "application/json",
+                schema
+        );
 
         return new GenerateContentRequest(
                 List.of(content),
@@ -149,7 +196,7 @@ public class GenerateContentRequest {
                 null,
                 null,
                 null,
-                null
+                generationConfig
         );
     }
 }

--- a/src/main/java/com/feelory/feelory_backend/global/webclient/dto/request/GenerateContentRequest.java
+++ b/src/main/java/com/feelory/feelory_backend/global/webclient/dto/request/GenerateContentRequest.java
@@ -6,6 +6,8 @@ import com.feelory.feelory_backend.global.webclient.dto.model.GeminiHarmBlockThr
 import com.feelory.feelory_backend.global.webclient.dto.model.GeminiPropertyType;
 import com.feelory.feelory_backend.global.webclient.dto.model.GeminiResponseType;
 import com.feelory.feelory_backend.global.webclient.dto.model.GeminiSafetyCategory;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.*;
 
 import java.util.List;
@@ -128,12 +130,28 @@ public class GenerateContentRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GenerationConfig {
-        private Double temperature;
-        private Integer topK;
-        private Double topP;
-        private Integer maxOutputTokens;
         private String responseMimeType;
         private Schema responseSchema;
+
+        @Min(value = 0, message = "최소 값 0.0")
+        @Max(value = 2, message = "최대 값 2.0")
+        private Double temperature;             // 응답의 무작위성(또는 독창성)을 제어함
+                                                // temperature 값이 높아질 수록 확률 분포가 뾰족해짐 -> 확률이 높은 토큰쪽으로 결정이 몰림
+        private Integer topK;                   // 높은 확률 기준으로 상위 K개의 응답만을 후보군으로 둠
+                                                // 권장되지 않음 -> 확률이 아닌 개수로 결정되기 때문
+        private Double topP;                    // 높은 확률 기준으로 후보군의 확률의 합이 P가 될때까지의 응답을 후보군에 포함시킴
+
+        private Integer maxOutputTokens;
+        private Integer candidateCount;         // 응답 후보군 수 지정, 기본값 : 1
+
+        private List<String> stopSequences;     // 응답 생성을 중단시키는 특정 문자열을 지정하는 옵션
+
+        private Double presencePenalty;         // 이미 사용된 단어를 반복할 시 주는 패널티 강도
+                                                // presencePenalty가 양수인 경우 -> 이미 사용된 단어(토큰)에 대한 확률을 기본값보다 더 낮춤
+                                                // presencePenalty가 음수인 경우 -> 이미 사용된 단어(토큰)에 대한 확률을 기본값보다 덜 낮춤
+        private Double frequencyPenalty;        // 자주 등장한 단어에 대해 부여하는 패널티 강도
+                                                // presencePenalty -> 등장 / 등장 X 여부에 따라 확률이 조정됨
+                                                // frequencyPenalty -> 등장 빈도에 따라 확률이 조정됨
     }
 
 
@@ -179,12 +197,16 @@ public class GenerateContentRequest {
         Schema schema = GeminiFeedbackSchemaMapper.schema();
 
         GenerationConfig generationConfig = new GenerationConfig(
-                null,
-                null,
-                null,
-                null,
                 "application/json",
-                schema
+                schema,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
         );
 
         return new GenerateContentRequest(


### PR DESCRIPTION
### ✨ 작업 개요
- Gemini 응답 시 JSON 객체로 파싱 가능하도록 기능 적용했습니다.

---

### 🔧 변경사항
- **ErrorCode.java**
  - Parsing 실패시의 오류 코드 추가 : `FEEDBACK_PARSING_FAILED`

- **GenerateContentRequest.java**
  - JSON 적용 위한 inner class 추가 (`Schema`, `Properties`, )
  - systemInstruction 분리
    - 챗봇을 사용할 때 persona라는 것을 생성해서 한다고 합니다.(https://wikidocs.net/259468)
    - 챗봇은 아니고 반드시 필요한 작업은 아니지만 의미를 분화해보고싶어서 systemInstruction을 나눴습니다.
  - JSON 응답을 받기 위한 generationConfig 추가

- Enum 다수 추가
  - JSON schema에서 사용하는 Enum을 추가했습니다.
    - GeminiPropertyType.java
    - GeminiResponseType.java
  - 추후 사용 여지가 있는 중단 사유에 관한 Enum을 추가했습니다.
    - GeminiFinishReason.java

- **GeminiFeedbackProperty.java**
  - JSON으로 응답받기 위해 Gemini에 던지는 메타데이터 정보를 담을 수 있는 기능을 제공하는 어노테이션을 추가했습니다.

- **GeminiFeedbackForm.java**
  - 두가지 용도로 사용됩니다.
    1. Gemini에서 응답 시 JSON에 포함되었으면 하는 필드의 메타데이터 정보를 추가할 때 사용합니다.
    2. Gemini의 응답을 Parsing 후 데이터를 담을 때 사용합니다.

- **GeminiFeedbackSchemaMapper.java**
  - `GeminiFeedbackForm.java`에 추가한 메타데이터 정보를 기반으로 Schema 객체를 구성할 때 사용합니다.
  - Schema 객체는 아래와 같은 방식으로 사용됩니다. 
    - `Schema로 변환 -> 변환된 객체를  generationConfig에 추가 -> generationConfig를 GenerateContentRequest에 추가`

---

### ⚡ 기타
1. annotation 관련
- 작성한 annotation을 `annotaion`이란 패키지를 새로 만들어 넣었습니다.
- 추후 말씀 나눌 때 변경 요청하시면 위치 변경하겠습니다.

2. objectMapper 관련
- 일단 이번 작업에서는 new로 새로 생성해서 작업했습니다.
- 설정 찾아보기 귀찮아서 일단 별도 빈으로 만들거나 config로 만들진 않았습니다.
- 추후에 일괄로 작업하려하는데 그래도 보기 별로라면 수정해서 올리겠습니다.

3. 작업한 파일 위치 관련
- 이번에 작업한 파일 위치들 보시고 좀 별로다 싶으시면 말씀해주세요. 수정하겠습니다. 