### PR TITLE
프로필 수정 / 유저 탈퇴 등 유저 API , JWT 인증 로직 개선

### DIFF
--- a/src/main/java/com/feelory/feelory_backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/feelory/feelory_backend/domain/user/controller/UserController.java
@@ -1,0 +1,37 @@
+package com.feelory.feelory_backend.domain.user.controller;
+
+import com.feelory.feelory_backend.domain.user.service.UserService;
+import com.feelory.feelory_backend.global.api.ApiResponse;
+import com.feelory.feelory_backend.global.api.SuccessCode;
+import com.feelory.feelory_backend.global.security.jwt.JwtProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+@Tag(name = "유저 (User)", description = "유저 관련 API 목록")
+public class UserController {
+
+    private final JwtProvider jwtProvider;
+    private final UserService userService;
+
+    @Operation(
+            summary = "유저 서비스 탈퇴(비활성화)",
+            description = "물리가 아닌 논리 삭제(isActive)로 유저를 탈퇴(비활성화) 처리합니다.",
+            security = {@SecurityRequirement(name = "JWT")}
+    )
+    @DeleteMapping(value = "")
+    public ApiResponse<Void> deleteUser() {
+
+        jwtProvider.checkUserOrAdmin();
+
+        userService.deleteUser();
+
+        return ApiResponse.success(SuccessCode.DELETE_USER_SUCCESS);
+    }
+}
+

--- a/src/main/java/com/feelory/feelory_backend/domain/user/controller/UserProfileController.java
+++ b/src/main/java/com/feelory/feelory_backend/domain/user/controller/UserProfileController.java
@@ -1,5 +1,6 @@
 package com.feelory.feelory_backend.domain.user.controller;
 
+import com.feelory.feelory_backend.domain.user.dto.request.UserProfileUpdateRequest;
 import com.feelory.feelory_backend.global.api.ApiResponse;
 import com.feelory.feelory_backend.global.api.SuccessCode;
 import com.feelory.feelory_backend.global.security.jwt.JwtProvider;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -52,5 +54,21 @@ public class UserProfileController {
         UserProfileResponse response = userProfileService.readUserProfile();
 
         return ApiResponse.success(response, SuccessCode.READ_USER_PROFILE_SUCCESS);
+    }
+
+    @Operation(
+            summary = "내 프로필 수정",
+            description = "프로필의 닉네임과 자기소개를 수정합니다.",
+            security = {@SecurityRequirement(name = "JWT")}
+    )
+    @PatchMapping(value = "/me")
+    public ApiResponse<Void> updateProfile(
+            @Valid @RequestBody UserProfileUpdateRequest request) {
+
+        jwtProvider.checkUserOrAdmin();
+
+        userProfileService.updateUserProfile(request);
+
+        return ApiResponse.success(SuccessCode.UPDATE_USER_PROFILE_SUCCESS);
     }
 }

--- a/src/main/java/com/feelory/feelory_backend/domain/user/dto/model/UserRole.java
+++ b/src/main/java/com/feelory/feelory_backend/domain/user/dto/model/UserRole.java
@@ -5,7 +5,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserRole {
     ANONYMOUS("익명 사용자"),
-    USER("사용자"),
+    DEACTIVATED_USER("비활성화된 사용자"),
+    USER("일반 사용자"),
     ADMIN("관리자");
 
     private final String description;

--- a/src/main/java/com/feelory/feelory_backend/domain/user/dto/request/UserProfileUpdateRequest.java
+++ b/src/main/java/com/feelory/feelory_backend/domain/user/dto/request/UserProfileUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.feelory.feelory_backend.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserProfileUpdateRequest {
+    @NotBlank(message = "닉네임 값은 필수 입니다.")
+    @Size(min = 2, max = 10, message = "닉네임은 2글자 이상, 10글자 이하이어야 합니다.")
+    private String nickname;
+
+    @Size(max = 200, message = "자기소개는 최대 200자 까지 입력 가능합니다.")
+    private String introduce;
+}

--- a/src/main/java/com/feelory/feelory_backend/domain/user/service/UserProfileService.java
+++ b/src/main/java/com/feelory/feelory_backend/domain/user/service/UserProfileService.java
@@ -1,5 +1,6 @@
 package com.feelory.feelory_backend.domain.user.service;
 
+import com.feelory.feelory_backend.domain.user.dto.request.UserProfileUpdateRequest;
 import com.feelory.feelory_backend.domain.user.entity.User;
 import com.feelory.feelory_backend.domain.user.entity.UserProfileImage;
 import com.feelory.feelory_backend.global.exception.exceptions.user.UserNotFoundException;
@@ -12,7 +13,6 @@ import com.feelory.feelory_backend.domain.user.dto.response.UserProfileResponse;
 import com.feelory.feelory_backend.domain.user.repository.UserProfileImageRepository;
 import com.feelory.feelory_backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -34,7 +34,7 @@ public class UserProfileService {
 
         ImageFileDto imageFileDto = fileUploadService.uploadImageFile(requestImageFile);
 
-        User user = getUsers(userId);
+        User user = getUser(userId);
 
         deactivateCurrentProfileImages(user);
 
@@ -52,13 +52,33 @@ public class UserProfileService {
 
         Long userId = jwtProvider.getUserIdFromAuthentication();
 
-        User user = getUsers(userId);
+        User user = getUser(userId);
 
         UserProfileImage activeProfileImage = getActiveProfileImageFromUser(user);
 
         String profileImageUrl = getProfileImageUrl(activeProfileImage);
 
         return buildUserProfileResponse(user,profileImageUrl);
+    }
+
+    @Transactional
+    public void updateUserProfile(UserProfileUpdateRequest request) {
+
+        Long userId = jwtProvider.getUserIdFromAuthentication();
+
+        User user = getUser(userId);
+
+        User updatedUser = updateUser(user,request);
+
+        userRepository.save(updatedUser);
+    }
+
+    private User updateUser(User user, UserProfileUpdateRequest request) {
+        User.UserBuilder builder = user.toBuilder();
+        builder.nickname(request.getNickname());
+        builder.introduce(request.getIntroduce());
+
+        return builder.build();
     }
 
     private UserProfileResponse buildUserProfileResponse(User user, String profileImageUrl) {
@@ -102,8 +122,9 @@ public class UserProfileService {
         return image;
     }
 
-    private User getUsers(Long userId) {
+    private User getUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
     }
+
 }

--- a/src/main/java/com/feelory/feelory_backend/domain/user/service/UserService.java
+++ b/src/main/java/com/feelory/feelory_backend/domain/user/service/UserService.java
@@ -1,12 +1,17 @@
 package com.feelory.feelory_backend.domain.user.service;
 
 import com.feelory.feelory_backend.domain.user.entity.User;
+import com.feelory.feelory_backend.domain.user.entity.UserToken;
+import com.feelory.feelory_backend.global.exception.exceptions.user.AlreadyDeletedUserException;
+import com.feelory.feelory_backend.global.exception.exceptions.user.UserNotFoundException;
+import com.feelory.feelory_backend.global.security.jwt.JwtProvider;
 import com.feelory.feelory_backend.global.util.NicknameGenerator;
 import com.feelory.feelory_backend.domain.user.dto.model.AuthProvider;
 import com.feelory.feelory_backend.domain.user.dto.model.UserRole;
 import com.feelory.feelory_backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,15 +19,16 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final NicknameGenerator nicknameGenerator;
+    private final JwtProvider jwtProvider;
 
     public User findOrCreateUser(String name, String phoneNumber, AuthProvider authProvider, Long providerUserId) {
         return userRepository.findByPhoneNumberAndIsActive(phoneNumber, true)
                 .orElseGet(() -> userRepository.save(
-                        createUsers(name, phoneNumber, authProvider, providerUserId)
+                        createUser(name, phoneNumber, authProvider, providerUserId)
                 ));
     }
 
-    private User createUsers(String userName, String phoneNumber, AuthProvider authProvider, Long providerUserId) {
+    private User createUser(String userName, String phoneNumber, AuthProvider authProvider, Long providerUserId) {
         return User.builder()
                 .name(userName)
                 .nickname(nicknameGenerator.generate())
@@ -36,5 +42,44 @@ public class UserService {
 
     public boolean isActiveUser(Long userId) {
         return userRepository.existsByIdAndIsActiveTrue(userId);
+    }
+
+    @Transactional
+    public void deleteUser() {
+        Long userId = jwtProvider.getUserIdFromAuthentication();
+
+        User user = getUser(userId);
+
+        validateAlreadyDeletedUser(user);
+
+        User deactivatedUser = deactivateUser(user);
+
+        deactivateUserHasTokens(deactivatedUser);
+
+        userRepository.save(deactivatedUser);
+    }
+
+    private void deactivateUserHasTokens(User deactivatedUser) {
+        for(UserToken userToken : deactivatedUser.getUserTokens()){
+            userToken.deactivate();
+        }
+    }
+
+    private void validateAlreadyDeletedUser(User user) {
+        if(!user.isActive()){
+            throw new AlreadyDeletedUserException();
+        }
+    }
+
+    private User deactivateUser(User user) {
+        User.UserBuilder builder = user.toBuilder();
+        builder.isActive(false);
+        builder.role(UserRole.DEACTIVATED_USER);
+        return builder.build();
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
     }
 }

--- a/src/main/java/com/feelory/feelory_backend/global/api/SuccessCode.java
+++ b/src/main/java/com/feelory/feelory_backend/global/api/SuccessCode.java
@@ -15,6 +15,7 @@ public enum SuccessCode {
     // USERS(사용자)
     REGISTER_USER_PROFILE_IMAGE_SUCCESS("유저 프로필 이미지 갱신 완료"),
     READ_USER_PROFILE_SUCCESS("유저 프로필 조회 완료"),
+    UPDATE_USER_PROFILE_SUCCESS("유저 프로필 수정 완료"),
 
     // WORDS(단어)
     GET_CATEGORY_LIST_SUCCESS("카테고리 목록 조회 완료"),

--- a/src/main/java/com/feelory/feelory_backend/global/api/SuccessCode.java
+++ b/src/main/java/com/feelory/feelory_backend/global/api/SuccessCode.java
@@ -16,6 +16,7 @@ public enum SuccessCode {
     REGISTER_USER_PROFILE_IMAGE_SUCCESS("유저 프로필 이미지 갱신 완료"),
     READ_USER_PROFILE_SUCCESS("유저 프로필 조회 완료"),
     UPDATE_USER_PROFILE_SUCCESS("유저 프로필 수정 완료"),
+    DELETE_USER_SUCCESS("유저 서비스 탈퇴 완료"),
 
     // WORDS(단어)
     GET_CATEGORY_LIST_SUCCESS("카테고리 목록 조회 완료"),

--- a/src/main/java/com/feelory/feelory_backend/global/exception/dto/model/ErrorCode.java
+++ b/src/main/java/com/feelory/feelory_backend/global/exception/dto/model/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     // E1XX : USER(사용자)
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "E100", "해당 유저를 찾을 수 없습니다."),
     INVALID_PHONE_NUMBER(HttpStatus.BAD_REQUEST, "E101", "유효하지 않은 전화번호 형식입니다."),
+    ALREADY_DELETED_USER(HttpStatus.BAD_REQUEST, "E102", "이미 탈퇴 처리가 완료된 회원입니다."),
 
     // E2XX : WORD(단어)
     WORD_NOT_FOUND(HttpStatus.NOT_FOUND, "E200", "단어를 찾을 수 없습니다."),

--- a/src/main/java/com/feelory/feelory_backend/global/exception/dto/model/ErrorCode.java
+++ b/src/main/java/com/feelory/feelory_backend/global/exception/dto/model/ErrorCode.java
@@ -11,10 +11,10 @@ public enum ErrorCode {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "E001", "접근 권한이 없습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "E002", "리프레시 토큰이 존재하지 않습니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "E003", "리프레시 토큰이 만료되었습니다."),
-    INVALID_TOKEN(HttpStatus.NOT_FOUND, "E004", "토큰 정보가 유효하지 않습니다."),
-    ADMIN_ACCESS_DENIED(HttpStatus.NOT_FOUND, "E005", "Admin 권한이 없습니다."),
-    USER_ACCESS_DENIED(HttpStatus.NOT_FOUND, "E006", "User 또는 Admin 권한이 없습니다."),
-    ILLEGAL_USER_TYPE(HttpStatus.NOT_FOUND, "E007", "잘못된 유저 타입입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "E004", "토큰 정보가 유효하지 않습니다."),
+    ADMIN_ACCESS_DENIED(HttpStatus.FORBIDDEN, "E005", "Admin 권한이 없습니다."),
+    USER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "E006", "User 또는 Admin 권한이 없습니다."),
+    ILLEGAL_USER_TYPE(HttpStatus.BAD_REQUEST, "E007", "잘못된 유저 타입입니다."),
     USER_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "E008", "로그인한 유저의 아이디 추출 시 오류가 발생했습니다."),
 
     // E1XX : USER(사용자)
@@ -52,9 +52,9 @@ public enum ErrorCode {
     UNSUPPORTED_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "E904", "지원하지 않는 이미지 파일 형식입니다."),
 
     // E9XX : 기타
-    DAY_TO_FAR_IN_PAST(HttpStatus.BAD_REQUEST, "994", "날짜는 현재로부터 이전 %개월 까지만 가능합니다."),
-    DAY_TO_FAR_IN_FUTURE(HttpStatus.BAD_REQUEST, "995", "날짜는 현재로부터 최후 %개월 까지만 가능합니다."),
-    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "996", "잘못된 날짜 형식입니다."),
+    DAY_TO_FAR_IN_PAST(HttpStatus.BAD_REQUEST, "E994", "날짜는 현재로부터 이전 %개월 까지만 가능합니다."),
+    DAY_TO_FAR_IN_FUTURE(HttpStatus.BAD_REQUEST, "E995", "날짜는 현재로부터 최후 %개월 까지만 가능합니다."),
+    INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "E996", "잘못된 날짜 형식입니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST,"E997", "입력값이 유효하지 않습니다."),
     NOT_FOUND_END_POINT(HttpStatus.INTERNAL_SERVER_ERROR, "E998", "요청한 API가 존재하지 않습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E999", "서버 내부 오류가 발생했습니다.");

--- a/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/user/AlreadyDeletedUserException.java
+++ b/src/main/java/com/feelory/feelory_backend/global/exception/exceptions/user/AlreadyDeletedUserException.java
@@ -1,0 +1,10 @@
+package com.feelory.feelory_backend.global.exception.exceptions.user;
+
+import com.feelory.feelory_backend.global.exception.dto.model.ErrorCode;
+import com.feelory.feelory_backend.global.exception.exceptions.BaseException;
+
+public class AlreadyDeletedUserException extends BaseException {
+    public AlreadyDeletedUserException() {
+        super(ErrorCode.ALREADY_DELETED_USER);
+    }
+}

--- a/src/main/java/com/feelory/feelory_backend/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/feelory/feelory_backend/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.feelory.feelory_backend.global.security.jwt;
 
+import com.feelory.feelory_backend.domain.user.service.UserService;
+import com.feelory.feelory_backend.global.exception.exceptions.auth.UserAccessDeniedException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.nio.file.AccessDeniedException;
 import java.util.Collections;
 
 @Component
@@ -20,6 +23,7 @@ import java.util.Collections;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
+    private final UserService userService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -31,6 +35,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             if (jwtProvider.validateToken(token)) {
                 Long userId = jwtProvider.getUserIdFromToken(token);
+
+                if (!userService.isActiveUser(userId)) {
+                    throw new UserAccessDeniedException();
+                }
+
                 String role = jwtProvider.getRoleFromToken(token);
 
                 UsernamePasswordAuthenticationToken authentication =

--- a/src/main/java/com/feelory/feelory_backend/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/feelory/feelory_backend/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,12 +1,13 @@
 package com.feelory.feelory_backend.global.security.jwt;
 
 import com.feelory.feelory_backend.domain.user.service.UserService;
-import com.feelory.feelory_backend.global.exception.exceptions.auth.UserAccessDeniedException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AccountExpiredException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -15,7 +16,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.nio.file.AccessDeniedException;
 import java.util.Collections;
 
 @Component
@@ -28,30 +28,36 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
+
         String header = request.getHeader("Authorization");
 
-        if (header != null && header.startsWith("Bearer ")) {
-            String token = header.substring(7);
-
-            if (jwtProvider.validateToken(token)) {
-                Long userId = jwtProvider.getUserIdFromToken(token);
-
-                if (!userService.isActiveUser(userId)) {
-                    throw new UserAccessDeniedException();
-                }
-
-                String role = jwtProvider.getRoleFromToken(token);
-
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(
-                                userId, null,
-                                Collections.singletonList(new SimpleGrantedAuthority("ROLE_"+role))
-                        );
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            }
+        if (header == null || !header.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
         }
+
+        String token = header.substring(7);
+        if (!jwtProvider.validateToken(token)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Long userId = jwtProvider.getUserIdFromToken(token);
+        if (!userService.isActiveUser(userId)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String role = jwtProvider.getRoleFromToken(token);
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(
+                        userId,
+                        null,
+                        Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role))
+                );
+
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/feelory/feelory_backend/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/feelory/feelory_backend/global/security/jwt/JwtProvider.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class JwtProvider {
     private final JwtProperties jwtProperties;
-    private final UserService userService;
 
     private Key getSigningKey() {
         byte[] keyBytes = Decoders.BASE64.decode(jwtProperties.getSecret());
@@ -62,8 +61,7 @@ public class JwtProvider {
                     .setSigningKey(getSigningKey())
                     .build()
                     .parseClaimsJws(token);
-            Long userId = getUserIdFromToken(token);
-            return userService.isActiveUser(userId);
+            return true;
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }


### PR DESCRIPTION
### ✨ 작업 개요
- 유저 서비스 관련 주요 기능 추가 및 개선
  - 프로필 수정 API 추가 (닉네임, 자기소개 변경)
  - 유저 탈퇴(비활성화) 기능 추가 (논리 삭제 방식)
  - JWT 인증 로직 개선
- 기존 예외 코드 적절한 HTTP STATUS로 변경

---

### 🔧 변경사항

* **`UserController.java`**
  * `DELETE /api/users` → 유저 서비스 탈퇴 API 추가

* **`UserProfileController.java`**
  * `PATCH /api/users/me` → 닉네임/자기소개 수정 API 추가

* **`UserRole.java`**
  * `DEACTIVATED_USER` (비활성 사용자) 역할 추가

* **`ErrorCode.java`**
  * HTTP 상태 코드 정정 (`FORBIDDEN`, `UNAUTHORIZED`, `BAD_REQUEST` 등)

* **`JwtAuthenticationFilter.java`**
  * JWT 인증 시 비활성 사용자 접근 차단
  * 토큰 검증 및 권한 부여 로직 단순화

* **`JwtProvider.java`**
  * `validateToken()` 단순화 (토큰 형식 검증만 수행)

---

### 📝 테스트 방법

1. **유저 탈퇴 테스트**
   - 로그인 후 `DELETE /api/users` 호출
   - 응답: `DELETE_USER_SUCCESS`
   - 동일 계정으로 다시 탈퇴 요청 시 → `ALREADY_DELETED_USER` 예외 발생

2. **프로필 수정 테스트**
   - 로그인 후 `PATCH /api/users/me` 요청 (JSON Body 예시):
     ```json
     {
       "nickname": "새닉네임",
       "introduce": "자기소개 글"
     }
     ```
   - 응답: `UPDATE_USER_PROFILE_SUCCESS`
